### PR TITLE
Local Function Runner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/frontend/node_modules
+.venv
+.keys

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 *DS_Store
 functions/ml/ml_deploy/data/
 functions/convert_ids/convert_ids_deploy/data/
+
+# ignore typical python caching files, compilation intermediates
+__pycache__/
+*.py[cod]
+*$py.class
+
+# ignore sensitive items
+.env
+/.keys/*

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,8 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 
+console.debug(import.meta);
+
 (async () => {
   /** mock api */
   if (new URL(window.location.href).searchParams.get("mock") === "true") {

--- a/functions/ml/ml_deploy/main.py
+++ b/functions/ml/ml_deploy/main.py
@@ -132,4 +132,4 @@ def run_pipeline(request):
         json_out["positive_genes"] = gp.positive_genes
         return (json_out, 200, headers)
     except:
-        "problem with geneplexus"
+        return ("problem with geneplexus", 500, headers)

--- a/local_runner/Dockerfile.frontend
+++ b/local_runner/Dockerfile.frontend
@@ -4,7 +4,7 @@ FROM oven/bun:latest
 # don't get invalidated by changes to the frontend code
 COPY ./frontend/package.json ./
 COPY ./frontend/bun.lockb ./
-
+RUN bunx msw init
 RUN bun install
 
 # copy the entire frontend (other examples copy in just "src", but we need the

--- a/local_runner/Dockerfile.frontend
+++ b/local_runner/Dockerfile.frontend
@@ -12,5 +12,7 @@ RUN bun install
 COPY ./frontend/ ./
 
 # run the vite dev server with the `--host` option, which allows it to accept
-# connections from non-local (i.e., outside the container) clients
-CMD ["bun", "run", "dev", "--", "--host"]
+# connections from non-local (i.e., outside the container) clients.
+# we also run it internally on port 5175 rather than remap 5173 (the default)
+# to 5175 on the host via docker, so the frontend URL in the logs is accurate.
+CMD ["bun", "run", "dev", "--", "--host", "--port", "5175"]

--- a/local_runner/Dockerfile.frontend
+++ b/local_runner/Dockerfile.frontend
@@ -1,0 +1,16 @@
+FROM oven/bun:latest
+
+# copy in the requirements first and install them, so that these cached layers
+# don't get invalidated by changes to the frontend code
+COPY ./frontend/package.json ./
+COPY ./frontend/bun.lockb ./
+
+RUN bun install
+
+# copy the entire frontend (other examples copy in just "src", but we need the
+# "public" folder as well)
+COPY ./frontend/ ./
+
+# run the vite dev server with the `--host` option, which allows it to accept
+# connections from non-local (i.e., outside the container) clients
+CMD ["bun", "run", "dev", "--", "--host"]

--- a/local_runner/Dockerfile.frontend
+++ b/local_runner/Dockerfile.frontend
@@ -1,5 +1,7 @@
 FROM oven/bun:latest
 
+WORKDIR /app
+
 # copy in the requirements first and install them, so that these cached layers
 # don't get invalidated by changes to the frontend code
 COPY ./frontend/package.json ./

--- a/local_runner/Dockerfile.frontend
+++ b/local_runner/Dockerfile.frontend
@@ -4,6 +4,7 @@ FROM oven/bun:latest
 # don't get invalidated by changes to the frontend code
 COPY ./frontend/package.json ./
 COPY ./frontend/bun.lockb ./
+
 RUN bunx msw init
 RUN bun install
 
@@ -15,4 +16,4 @@ COPY ./frontend/ ./
 # connections from non-local (i.e., outside the container) clients.
 # we also run it internally on port 5175 rather than remap 5173 (the default)
 # to 5175 on the host via docker, so the frontend URL in the logs is accurate.
-CMD ["bun", "run", "dev", "--", "--host", "--port", "5175"]
+CMD ["bun", "run", "dev", "--host", "--port", "5175"]

--- a/local_runner/README.md
+++ b/local_runner/README.md
@@ -1,0 +1,96 @@
+# Local GCP Function Runner
+
+This folder contains a Docker Compose stack that uses GCP's
+[functions-framework](https://github.com/GoogleCloudPlatform/functions-framework-python),
+specifically the CLI for running a function locally on a specific port, to run
+our cloud functions locally for development and testing. The functions are
+aggregated into a single backend using [Caddy](https://caddyserver.com/), which
+is served at http://localhost:9035. As a convenience, the stack also launches
+the frontend at http://localhost:5175 and configures it to query our local
+functions rather than the production URL.
+
+This stack requires the following to be installed on your machine:
+- [Docker](https://docs.docker.com/get-docker/)
+- `Docker Compose`, but this comes bundles in contemporary versions of Docker
+- an environment that can run bash scripts, i.e. Linux, Mac OS X or Windows with
+  WSL
+
+## How to Use it
+
+In the project root, execute `./run_local.sh`; this will take a little bit of
+time the first time as it installs dependencies as part of building the images,
+but subsequent runs should be quick thanks to the Docker layer cache.
+
+The script launches the stack, then tails the logs for each container; pressing
+`Ctrl-C` will quit tailing the logs, but it won't bring down the stack.
+Re-running `./run_local.sh` will restart the stack if there are configuration
+changes that require it, so you typically don't need to bring it down. If you
+really need to bring down the stack, you can `cd ./local_runner` and run `docker
+compose down` to bring it down.
+
+Whenever you modify your functions' `requirements.txt` or the frontend's
+`package.json`, you'll want to re-run `run_local.sh`, as it'll have to rebuild
+the images.
+
+
+## Live Reloading
+
+The stack was put together with live editing in mind: changes to the functions
+and frontend will be immediately applied. In the frontend's case, this is
+supported by vite's dev server, which reloads code changes by default. In the
+local functions' case, this is accomplished by using
+[watchdog](https://github.com/gorakhargosh/watchdog) to monitor changes to each
+functions' source code and restart the `functions-framework` instance when
+changes occur.
+
+
+## Why Caddy? Reverse Proxy Details
+
+The `functions-framework` CLI can only launch a single function on a given port.
+This poses a problem for the frontend, which expects that all the functions are
+served under a single origin (i.e., a protocol + domain name + port) with
+different paths corresponding to different functions.
+
+To work around this, we serve each function internally on a known port, then use
+Caddy to map each function runner's port to a path on the proxy. For example,
+the `gpz-convert-ids` function runs internally on port 8080 and `gpz-ml` runs on
+port 8081. Caddy, running on port 9035 proxies requests to
+`http//localhost:9035/gpz-convert-ids` to `http://localhost:8080` and requests
+to `http//localhost:9035/gpz-ml` to `http://localhost:8081`.
+
+
+### Adding Functions to Caddy
+
+To add additional functions, you'll first need to modify
+`./local_runner/backend/Dockerfile`.
+
+```Dockerfile
+COPY ./functions/<path_to_requirements.txt> /tmp/_requirements.txt
+RUN pip install -r /tmp/_requirements.txt
+```
+
+Then, you'll need to modify `./local_runner/backend/entrypoint.sh`. You'll then
+need to add a line like the following under the existing `launch_and_watch`
+lines:
+```bash
+( launch_and_watch /app/functions/<function_src_folder> <entrypoint> <ununsed_port> ) &
+```
+
+Where:
+- `<function_src_folder>` is the path to function's code below `./functions`,
+- `<entrypoint>` is the name of the Python function in your source code that's
+invoked when someone queries the function, and
+- `<unused_port>` is any port that's unused; note that these ports are not
+exposed on the host, just within the backend container
+
+Second, in `./local_runner/backend/Caddyfile`, you'll need to add a line like
+the following under the existing `reverse_proxy` lines:
+```
+reverse_proxy /<path_to_func> localhost:<unused_port>
+```
+
+Where:
+- `<path_to_func>` is the path you want to use to call the function under
+  `http://localhost:9035`, and
+- `<unused_port>` is the port you chose in the previous step.
+

--- a/local_runner/backend/Caddyfile
+++ b/local_runner/backend/Caddyfile
@@ -1,0 +1,8 @@
+{
+	auto_https disable_redirects
+}
+
+http:// {
+	reverse_proxy /gpz-convert-ids localhost:8080
+	reverse_proxy /gpz-ml localhost:8081
+}

--- a/local_runner/backend/Dockerfile
+++ b/local_runner/backend/Dockerfile
@@ -1,0 +1,37 @@
+FROM python:3.11
+
+# install the following tools:
+# - caddy, a reverse proxy that will serve the functions
+# - inotify-tools to watch for file changes
+RUN apt-get update && apt-get install -y \
+    caddy inotify-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+# install functions-framework, which will run each function, as well as the tool
+# watchmedo (in package watchdog) to restart each functions-framework instance
+# when there are code changes to the function
+RUN pip install functions-framework watchdog
+
+# copy the caddy config that will be used to proxy from functions-framework
+# ports to a single origin
+COPY ./local_runner/backend/Caddyfile /etc/caddy/Caddyfile
+
+# copy in each functions' requirements.txt and install the dependencies
+# (we're reusing /tmp/_requirements.txt so we don't litter the temp folder
+# with near-identical requirements files, but you can name them whatever
+# you want so long as you use the same name in the pip install step)
+# 1. convert_ids requirements
+COPY ./functions/convert_ids/convert_ids_deploy/requirements.txt /tmp/_requirements.txt
+RUN pip install -r /tmp/_requirements.txt
+# 2. ml requirements
+COPY ./functions/ml/ml_deploy/requirements.txt /tmp/_requirements.txt
+RUN pip install -r /tmp/_requirements.txt
+# <NOTE: additional copy/run pairs for each function should be added here>
+
+# copy the entrypoint script that will start the functions via
+# functions-framework
+COPY ./local_runner/backend/entrypoint.sh /opt/entrypoint.sh
+
+WORKDIR /app
+
+CMD ["/opt/entrypoint.sh"]

--- a/local_runner/backend/entrypoint.sh
+++ b/local_runner/backend/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# serves a function via functions-framework on a given port,
+# wrapped in watchmedo to restart it in case it's changed
+# takes the following positional arguments:
+# 1. the directory containing the function
+# 2. the entrypoint of the function
+# 3. the port on which to serve the function (must match the caddyfile)
+function launch_and_watch() {
+    cd $1
+    watchmedo auto-restart \
+        --directory . --pattern="*.py" --recursive -- \
+        functions-framework --target="$2" --port="$3"
+}
+
+# launch each function in a separate process and background it
+( launch_and_watch /app/functions/convert_ids/convert_ids_deploy convert_ids 8080)  &
+( launch_and_watch /app/functions/ml/ml_deploy run_pipeline 8081 ) &
+
+# run caddy to serve the functions we're watching from a single origin
+/usr/bin/caddy run --environ --config /etc/caddy/Caddyfile

--- a/local_runner/docker-compose.yml
+++ b/local_runner/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - VITE_API=http://localhost:9035
     volumes:
       # allows the vite dev server to pick up source changes
-      - ../frontend/src/:/home/bun/app/src/
+      - ../frontend/src/:/app/src
 
   backend:
     ports:

--- a/local_runner/docker-compose.yml
+++ b/local_runner/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - VITE_API=http://localhost:9035
     volumes:
       # allows the vite dev server to pick up source changes
-      - ../frontend/src/:/app/src/
+      - ../frontend/src/:/home/bun/app/src/
 
   backend:
     ports:

--- a/local_runner/docker-compose.yml
+++ b/local_runner/docker-compose.yml
@@ -3,7 +3,7 @@ name: geneplexus-local
 services:
   frontend:
     ports:
-      - 5175:5173
+      - 5175:5175
     build:
       context: ..
       dockerfile: local_runner/Dockerfile.frontend

--- a/local_runner/docker-compose.yml
+++ b/local_runner/docker-compose.yml
@@ -1,0 +1,24 @@
+name: geneplexus-local
+
+services:
+  frontend:
+    ports:
+      - 5175:5173
+    build:
+      context: ..
+      dockerfile: local_runner/Dockerfile.frontend
+    environment:
+      - VITE_API=http://localhost:9035
+    volumes:
+      # allows the vite dev server to pick up source changes
+      - ../frontend/src/:/app/src/
+
+  backend:
+    ports:
+      - 9035:80
+    build:
+      context: ..
+      dockerfile: local_runner/backend/Dockerfile
+    volumes:
+      # allows watchdog to restart functions-framework when there are changes
+      - ../functions/:/app/functions/

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+COMPOSE_CMD="docker compose -f local_runner/docker-compose.yml"
+
+${COMPOSE_CMD} up --build -d && \
+${COMPOSE_CMD} logs -f frontend backend


### PR DESCRIPTION
This PR adds a mechanism for testing cloud functions locally via Google's `functions-framework` package. This should allow us to more rapidly develop the functions without having to deploy them to production each time. As a convenience, it also launches the frontend and directs it to use the local functions rather than the production ones.

Assuming you have Docker installed, you can run it quickly by executing `run_local.sh` in the project root; I'm happy to relocate this script somewhere less visible if you all prefer. Once you execute it and it's launched, you should be able to browse to `http://localhost:5175` to see the frontend. Modifying the frontend or backend functions' code should immediately take effect. See `./local_runner/README.md` for details.