### PR TITLE
Only run test-frontend workflow on frontend changes

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -1,6 +1,10 @@
 name: Test Frontend
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - 'package.json'
 
 defaults:
   run:


### PR DESCRIPTION
Hey @vincerubinetti, I hope it's ok to suggest this; feel free to reject if you don't think it's a good change.

Anyway, this PR just constraints the test-frontend.yaml workflow to run only when anything under `frontend/` has changed. I included the root `package.json`, too, since it looked related to the frontend, but tweak as you see fit.