### PR TITLE
Rearrange new analysis page

### DIFF
--- a/frontend/src/components/Toasts.module.css
+++ b/frontend/src/components/Toasts.module.css
@@ -1,13 +1,3 @@
-.list {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  width: max-content;
-  max-width: min(340px, 100vw);
-  margin-bottom: 20px;
-  padding: 10px;
-}
-
 .toast {
   display: grid;
   grid-template-columns: min-content 1fr min-content;

--- a/frontend/src/components/Toasts.tsx
+++ b/frontend/src/components/Toasts.tsx
@@ -49,7 +49,6 @@ const Toasts = () => {
       direction="column"
       hAlign="stretch"
       gap="sm"
-      className={classes.list}
       role="region"
       aria-label="Notifications"
     >

--- a/frontend/src/components/ViewCorner.module.css
+++ b/frontend/src/components/ViewCorner.module.css
@@ -1,4 +1,5 @@
 .list {
+  z-index: 3;
   position: fixed;
   right: 0;
   bottom: 0;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -38,13 +38,9 @@ const HomePage = () => {
 
       <Section>
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat. Duis aute irure dolor in
-          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-          culpa qui officia deserunt mollit anim id est laborum.
+          GenePlexus trains a custom model on your gene set to predict new
+          genes, compare to known processes and phenotypes, and view network
+          connections.
         </p>
       </Section>
     </>

--- a/frontend/src/pages/NewAnalysis.module.css
+++ b/frontend/src/pages/NewAnalysis.module.css
@@ -21,10 +21,3 @@
 .divider {
   grid-column: 1 / -1;
 }
-
-.parameters {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 40px;
-}


### PR DESCRIPTION
Based on Chris's sketch here:

[20240924_UI_thoughts[12].pdf](https://github.com/user-attachments/files/17604167/20240924_UI_thoughts.12.pdf)

I have made tweaks though, because the wording and order of things needed to be changed. For example, if we're going to put the negatives in the options section, the "Check genes" section needs to come after it because it also checks those. Generally, it is clearer if something the user inputs (negatives) doesn't affect anything that came before it (check genes results).

- fix css z-index bug in toasts/view corner
- add another summarizing sentence to home page
- new analysis page changes 
  - make "inputType" case insensitive (backend/package seems to normalize input genes to uppercase). make more succinct by just using `+` and `-` chars
  - move species selects to first section, side by side, with arrow in between
  - remove "show negatives" checkbox and move negatives text box to parameters section
  - rename "choose parameters" section to "options", and wrap in collapsible
  - rename "check genes" section to "pre-check" genes to make it more clear at a glance what it's for. hide paragraph of explanatory text in tooltip for clean-ness.
